### PR TITLE
Fix guest password cloud sync

### DIFF
--- a/src/__tests__/unit/passwords-page-sync.spec.tsx
+++ b/src/__tests__/unit/passwords-page-sync.spec.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import PasswordsPage from '@/app/passwords/page';
+import { useToast } from '@/components/ui/use-toast';
+import { usePasswordStorage } from '@/hooks/use-password-storage';
+import { useSession } from '@/lib/auth-client';
+
+jest.mock('@/lib/auth-client', () => ({
+  useSession: jest.fn(),
+}));
+
+jest.mock('@/hooks/use-password-storage', () => ({
+  usePasswordStorage: jest.fn(),
+}));
+
+jest.mock('@/components/ui/use-toast', () => ({
+  useToast: jest.fn(),
+}));
+
+const mockUseSession = useSession as jest.Mock;
+const mockUsePasswordStorage = usePasswordStorage as jest.Mock;
+const mockUseToast = useToast as jest.Mock;
+
+describe('PasswordsPage sync behavior', () => {
+  const getPasswordsMock = jest.fn();
+  const deletePasswordMock = jest.fn();
+  const toastMock = jest.fn();
+  type HookState = {
+    getPasswords: typeof getPasswordsMock;
+    deletePassword: typeof deletePasswordMock;
+    isSyncingLocalPasswords: boolean;
+    lastLocalSyncResult: { synced: number; failed: number } | null;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSession.mockReturnValue({
+      data: {
+        session: { id: 'sess_123' },
+        user: { id: 'user_123' },
+      },
+      isPending: false,
+    });
+    mockUseToast.mockReturnValue({ toast: toastMock });
+  });
+
+  it('shows loading while sync is in progress and does not call getPasswords()', () => {
+    mockUsePasswordStorage.mockReturnValue({
+      getPasswords: getPasswordsMock,
+      deletePassword: deletePasswordMock,
+      isSyncingLocalPasswords: true,
+      lastLocalSyncResult: null,
+    });
+
+    render(<PasswordsPage />);
+
+    expect(screen.getByText(/loading passwords/i)).toBeInTheDocument();
+    expect(getPasswordsMock).not.toHaveBeenCalled();
+  });
+
+  it('reloads the vault after sync finishes and renders cloud-backed passwords', async () => {
+    const cloudPasswords = [
+      {
+        id: 'cloud-1',
+        password: 'cloud-secret',
+        length: 12,
+        uppercase: true,
+        lowercase: true,
+        numbers: true,
+        symbols: false,
+        createdAt: '2026-01-03T00:00:00.000Z',
+      },
+    ];
+
+    getPasswordsMock.mockResolvedValue(cloudPasswords);
+
+    let hookState: HookState = {
+      getPasswords: getPasswordsMock,
+      deletePassword: deletePasswordMock,
+      isSyncingLocalPasswords: true,
+      lastLocalSyncResult: null,
+    };
+
+    mockUsePasswordStorage.mockImplementation(() => hookState);
+
+    const { rerender } = render(<PasswordsPage />);
+
+    expect(screen.getByText(/loading passwords/i)).toBeInTheDocument();
+    expect(getPasswordsMock).not.toHaveBeenCalled();
+
+    hookState = {
+      ...hookState,
+      isSyncingLocalPasswords: false,
+      lastLocalSyncResult: { synced: 2, failed: 0 },
+    };
+
+    rerender(<PasswordsPage />);
+
+    await waitFor(() => {
+      expect(getPasswordsMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(await screen.findByText('cloud-secret')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/unit/use-password-storage.spec.tsx
+++ b/src/__tests__/unit/use-password-storage.spec.tsx
@@ -1,0 +1,415 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { StoredPassword } from '@/hooks/use-password-storage';
+import { usePasswordStorage } from '@/hooks/use-password-storage';
+import { useSession } from '@/lib/auth-client';
+
+jest.mock('@/lib/auth-client', () => ({
+  useSession: jest.fn(),
+}));
+
+const mockUseSession = useSession as jest.Mock;
+
+const LOCAL_STORAGE_KEY = 'lock-genius-passwords';
+
+const basePassword = {
+  password: 'password-0',
+  length: 12,
+  uppercase: true,
+  lowercase: true,
+  numbers: true,
+  symbols: false,
+} satisfies Omit<StoredPassword, 'id' | 'createdAt'>;
+
+const makeStoredPassword = (
+  overrides: Partial<StoredPassword> & { createdAt?: Date }
+): StoredPassword => ({
+  id: overrides.id ?? crypto.randomUUID(),
+  password: overrides.password ?? 'password-1',
+  length: overrides.length ?? 12,
+  uppercase: overrides.uppercase ?? true,
+  lowercase: overrides.lowercase ?? true,
+  numbers: overrides.numbers ?? true,
+  symbols: overrides.symbols ?? false,
+  createdAt: overrides.createdAt ?? new Date('2026-01-01T00:00:00.000Z'),
+});
+
+const toPersistedPassword = (password: StoredPassword) => ({
+  ...password,
+  createdAt: password.createdAt.toISOString(),
+});
+
+const mockResponse = (body: unknown, ok = true) =>
+  ({
+    ok,
+    json: async () => body,
+  }) as Response;
+
+describe('usePasswordStorage', () => {
+  let fetchMock: jest.Mock;
+  let randomUuidSpy: jest.SpyInstance<string, []>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as typeof fetch;
+    randomUuidSpy = jest.spyOn(crypto, 'randomUUID').mockImplementation(() => {
+      return `uuid-${Math.random().toString(36).slice(2, 10)}`;
+    });
+  });
+
+  afterEach(() => {
+    randomUuidSpy.mockRestore();
+  });
+
+  it('writes guest passwords to localStorage and caps the list at 50', async () => {
+    mockUseSession.mockReturnValue({
+      data: null,
+      isPending: false,
+    });
+
+    const { result } = renderHook(() => usePasswordStorage());
+
+    await act(async () => {
+      for (let index = 0; index < 51; index += 1) {
+        await result.current.savePassword({
+          ...basePassword,
+          password: `password-${index}`,
+        });
+      }
+    });
+
+    const persisted = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) ?? '[]') as Array<{
+      id: string;
+    }>;
+
+    expect(persisted).toHaveLength(50);
+    expect(result.current.passwords).toHaveLength(50);
+  });
+
+  it('posts guest passwords after authentication and removes local storage on success', async () => {
+    const localPasswords = [
+      makeStoredPassword({
+        id: 'local-1',
+        password: 'alpha',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+      makeStoredPassword({
+        id: 'local-2',
+        password: 'beta',
+        createdAt: new Date('2026-01-02T00:00:00.000Z'),
+      }),
+    ];
+
+    localStorage.setItem(
+      LOCAL_STORAGE_KEY,
+      JSON.stringify(localPasswords.map(toPersistedPassword))
+    );
+
+    mockUseSession.mockReturnValue({
+      data: {
+        session: { id: 'sess_123' },
+        user: { id: 'user_123' },
+      },
+      isPending: false,
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(mockResponse([], true))
+      .mockResolvedValueOnce(mockResponse({ id: 'saved-1' }, true))
+      .mockResolvedValueOnce(mockResponse({ id: 'saved-2' }, true));
+
+    const { result } = renderHook(() => usePasswordStorage());
+
+    await waitFor(() => {
+      expect(result.current.lastLocalSyncResult).toEqual({ synced: 2, failed: 0 });
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(localStorage.getItem(LOCAL_STORAGE_KEY)).toBeNull();
+
+    const firstPostBody = JSON.parse(fetchMock.mock.calls[1][1]?.body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(firstPostBody).toEqual({
+      password: 'alpha',
+      length: 12,
+      uppercase: true,
+      lowercase: true,
+      numbers: true,
+      symbols: false,
+    });
+    expect(firstPostBody).not.toHaveProperty('id');
+    expect(firstPostBody).not.toHaveProperty('createdAt');
+  });
+
+  it('skips passwords that already exist in cloud by fingerprint', async () => {
+    const matchingPassword = makeStoredPassword({
+      id: 'local-1',
+      password: 'alpha',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    const newPassword = makeStoredPassword({
+      id: 'local-2',
+      password: 'beta',
+      createdAt: new Date('2026-01-02T00:00:00.000Z'),
+    });
+
+    localStorage.setItem(
+      LOCAL_STORAGE_KEY,
+      JSON.stringify([matchingPassword, newPassword].map(toPersistedPassword))
+    );
+
+    mockUseSession.mockReturnValue({
+      data: {
+        session: { id: 'sess_123' },
+        user: { id: 'user_123' },
+      },
+      isPending: false,
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse(
+          [
+            {
+              id: 'cloud-1',
+              password: 'alpha',
+              length: 12,
+              uppercase: true,
+              lowercase: true,
+              numbers: true,
+              symbols: false,
+              createdAt: '2026-01-03T00:00:00.000Z',
+            },
+          ],
+          true
+        )
+      )
+      .mockResolvedValueOnce(mockResponse({ id: 'saved-2' }, true));
+
+    const { result } = renderHook(() => usePasswordStorage());
+
+    await waitFor(() => {
+      expect(result.current.lastLocalSyncResult).toEqual({ synced: 2, failed: 0 });
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(localStorage.getItem(LOCAL_STORAGE_KEY)).toBeNull();
+
+    const postBody = JSON.parse(fetchMock.mock.calls[1][1]?.body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(postBody.password).toBe('beta');
+  });
+
+  it('keeps only failed passwords when a sync POST returns a non-2xx response', async () => {
+    const successPassword = makeStoredPassword({
+      id: 'local-1',
+      password: 'alpha',
+    });
+    const failedPassword = makeStoredPassword({
+      id: 'local-2',
+      password: 'beta',
+    });
+
+    localStorage.setItem(
+      LOCAL_STORAGE_KEY,
+      JSON.stringify([successPassword, failedPassword].map(toPersistedPassword))
+    );
+
+    mockUseSession.mockReturnValue({
+      data: {
+        session: { id: 'sess_123' },
+        user: { id: 'user_123' },
+      },
+      isPending: false,
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(mockResponse([], true))
+      .mockResolvedValueOnce(mockResponse({ id: 'saved-1' }, true))
+      .mockResolvedValueOnce(mockResponse({ error: 'failure' }, false));
+
+    const { result } = renderHook(() => usePasswordStorage());
+
+    await waitFor(() => {
+      expect(result.current.lastLocalSyncResult).toEqual({ synced: 1, failed: 1 });
+    });
+
+    const persisted = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) ?? '[]') as Array<{
+      id: string;
+      password: string;
+    }>;
+
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].id).toBe('local-2');
+    expect(persisted[0].password).toBe('beta');
+  });
+
+  it('keeps only failed passwords when a sync POST rejects', async () => {
+    const successPassword = makeStoredPassword({
+      id: 'local-1',
+      password: 'alpha',
+    });
+    const failedPassword = makeStoredPassword({
+      id: 'local-2',
+      password: 'beta',
+    });
+
+    localStorage.setItem(
+      LOCAL_STORAGE_KEY,
+      JSON.stringify([successPassword, failedPassword].map(toPersistedPassword))
+    );
+
+    mockUseSession.mockReturnValue({
+      data: {
+        session: { id: 'sess_123' },
+        user: { id: 'user_123' },
+      },
+      isPending: false,
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(mockResponse([], true))
+      .mockResolvedValueOnce(mockResponse({ id: 'saved-1' }, true))
+      .mockRejectedValueOnce(new Error('network failure'));
+
+    const { result } = renderHook(() => usePasswordStorage());
+
+    await waitFor(() => {
+      expect(result.current.lastLocalSyncResult).toEqual({ synced: 1, failed: 1 });
+    });
+
+    const persisted = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) ?? '[]') as Array<{
+      id: string;
+      password: string;
+    }>;
+
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].id).toBe('local-2');
+    expect(persisted[0].password).toBe('beta');
+  });
+
+  it('maps authenticated getPasswords results to Date instances', async () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        session: { id: 'sess_123' },
+        user: { id: 'user_123' },
+      },
+      isPending: false,
+    });
+
+    fetchMock.mockResolvedValueOnce(
+      mockResponse(
+        [
+          {
+            id: 'cloud-1',
+            password: 'alpha',
+            length: 12,
+            uppercase: true,
+            lowercase: true,
+            numbers: true,
+            symbols: false,
+            createdAt: '2026-01-03T00:00:00.000Z',
+          },
+        ],
+        true
+      )
+    );
+
+    const { result } = renderHook(() => usePasswordStorage());
+
+    const passwords = await result.current.getPasswords();
+
+    expect(passwords[0]?.createdAt).toBeInstanceOf(Date);
+    expect(passwords[0]?.createdAt.toISOString()).toBe('2026-01-03T00:00:00.000Z');
+  });
+
+  it('updates lastLocalSyncResult after a sync attempt', async () => {
+    localStorage.setItem(
+      LOCAL_STORAGE_KEY,
+      JSON.stringify(
+        [
+          makeStoredPassword({
+            id: 'local-1',
+            password: 'alpha',
+          }),
+        ].map(toPersistedPassword)
+      )
+    );
+
+    mockUseSession.mockReturnValue({
+      data: {
+        session: { id: 'sess_123' },
+        user: { id: 'user_123' },
+      },
+      isPending: false,
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(mockResponse([], true))
+      .mockResolvedValueOnce(mockResponse({ id: 'saved-1' }, true));
+
+    const { result } = renderHook(() => usePasswordStorage());
+
+    await waitFor(() => {
+      expect(result.current.lastLocalSyncResult).toEqual({ synced: 1, failed: 0 });
+    });
+  });
+
+  it('shares one in-flight sync promise across mounted hook instances for the same identity', async () => {
+    localStorage.setItem(
+      LOCAL_STORAGE_KEY,
+      JSON.stringify(
+        [
+          makeStoredPassword({
+            id: 'local-1',
+            password: 'alpha',
+          }),
+        ].map(toPersistedPassword)
+      )
+    );
+
+    mockUseSession.mockReturnValue({
+      data: {
+        session: { id: 'sess_123' },
+        user: { id: 'user_123' },
+      },
+      isPending: false,
+    });
+
+    let resolveGetPasswords!: (value: Response) => void;
+    const getPasswordsPromise = new Promise<Response>((resolve) => {
+      resolveGetPasswords = resolve;
+    });
+
+    fetchMock.mockImplementation((_input, init) => {
+      if (!init || init.method === undefined || init.method === 'GET') {
+        return getPasswordsPromise;
+      }
+
+      return Promise.resolve(mockResponse({ id: 'saved-1' }, true));
+    });
+
+    const firstHook = renderHook(() => usePasswordStorage());
+    const secondHook = renderHook(() => usePasswordStorage());
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    resolveGetPasswords(mockResponse([], true));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    await waitFor(() => {
+      expect(firstHook.result.current.lastLocalSyncResult).toEqual({ synced: 1, failed: 0 });
+      expect(secondHook.result.current.lastLocalSyncResult).toEqual({ synced: 1, failed: 0 });
+    });
+  });
+});

--- a/src/app/passwords/page.tsx
+++ b/src/app/passwords/page.tsx
@@ -22,20 +22,10 @@ import { useToast } from '@/components/ui/use-toast';
 import { type StoredPassword, usePasswordStorage } from '@/hooks/use-password-storage';
 import { useSession } from '@/lib/auth-client';
 
-interface LocalStoredPassword {
-  id: string;
-  password: string;
-  length: number;
-  uppercase: boolean;
-  lowercase: boolean;
-  numbers: boolean;
-  symbols: boolean;
-  createdAt: string;
-}
-
 export default function PasswordsPage() {
   const { data, isPending } = useSession();
-  const { getPasswords, deletePassword } = usePasswordStorage();
+  const { getPasswords, deletePassword, isSyncingLocalPasswords, lastLocalSyncResult } =
+    usePasswordStorage();
   const { toast } = useToast();
   const [passwords, setPasswords] = useState<StoredPassword[]>([]);
   const [loading, setLoading] = useState(true);
@@ -45,23 +35,8 @@ export default function PasswordsPage() {
   const loadPasswords = useCallback(async () => {
     try {
       setLoading(true);
-
-      if (isAuthenticated) {
-        const fetchedPasswords = await getPasswords();
-        setPasswords(fetchedPasswords);
-      } else {
-        const stored = localStorage.getItem('lock-genius-passwords');
-        if (stored) {
-          const passwords = JSON.parse(stored);
-          const parsedPasswords = passwords.map((p: LocalStoredPassword) => ({
-            ...p,
-            createdAt: new Date(p.createdAt),
-          }));
-          setPasswords(parsedPasswords);
-        } else {
-          setPasswords([]);
-        }
-      }
+      const fetchedPasswords = await getPasswords();
+      setPasswords(fetchedPasswords);
     } catch (_error) {
       toast({
         title: 'Error loading passwords',
@@ -71,13 +46,14 @@ export default function PasswordsPage() {
     } finally {
       setLoading(false);
     }
-  }, [isAuthenticated, getPasswords, toast]);
+  }, [getPasswords, toast]);
 
   useEffect(() => {
-    if (!isPending) {
+    if (!isPending && !isSyncingLocalPasswords) {
+      void lastLocalSyncResult;
       loadPasswords();
     }
-  }, [isPending, loadPasswords]);
+  }, [isPending, isSyncingLocalPasswords, lastLocalSyncResult, loadPasswords]);
 
   const handleDeletePassword = async (id: string) => {
     try {
@@ -114,7 +90,7 @@ export default function PasswordsPage() {
     }
   };
 
-  if (isPending || loading) {
+  if (isPending || isSyncingLocalPasswords || loading) {
     return (
       <div className="container mx-auto px-4 py-8">
         <div className="flex items-center justify-center">

--- a/src/hooks/use-password-storage.ts
+++ b/src/hooks/use-password-storage.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSession } from '@/lib/auth-client';
 
 export interface StoredPassword {
@@ -36,35 +36,224 @@ interface ApiStoredPassword {
 
 const LOCAL_STORAGE_KEY = 'lock-genius-passwords';
 const MAX_LOCAL_PASSWORDS = 50;
+type LocalSyncResult = { synced: number; failed: number };
+
+let localSyncInFlight: { identity: string; promise: Promise<LocalSyncResult> } | null = null;
+let lastCompletedLocalSyncIdentity: string | null = null;
+
+const toPersistedPassword = (password: StoredPassword): LocalStoredPassword => ({
+  ...password,
+  createdAt: password.createdAt.toISOString(),
+});
+
+const readLocalPasswords = (): StoredPassword[] => {
+  try {
+    const stored = localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (!stored) return [];
+
+    const parsed: unknown = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.map((password) => {
+      const persisted = password as LocalStoredPassword;
+
+      return {
+        ...persisted,
+        createdAt: new Date(persisted.createdAt),
+      };
+    });
+  } catch {
+    return [];
+  }
+};
+
+const writeLocalPasswords = (passwords: StoredPassword[]): void => {
+  localStorage.setItem(
+    LOCAL_STORAGE_KEY,
+    JSON.stringify(passwords.map((password) => toPersistedPassword(password)))
+  );
+};
+
+const fingerprintPassword = (
+  password: Pick<
+    StoredPassword,
+    'password' | 'length' | 'uppercase' | 'lowercase' | 'numbers' | 'symbols'
+  >
+): string =>
+  JSON.stringify([
+    password.password,
+    password.length,
+    password.uppercase,
+    password.lowercase,
+    password.numbers,
+    password.symbols,
+  ]);
+
+const toPasswordPayload = (
+  password: Pick<
+    StoredPassword,
+    'password' | 'length' | 'uppercase' | 'lowercase' | 'numbers' | 'symbols'
+  >
+): Omit<StoredPassword, 'id' | 'createdAt'> => ({
+  password: password.password,
+  length: password.length,
+  uppercase: password.uppercase,
+  lowercase: password.lowercase,
+  numbers: password.numbers,
+  symbols: password.symbols,
+});
 
 export const usePasswordStorage = () => {
   const { data, isPending } = useSession();
   const [localPasswords, setLocalPasswords] = useState<StoredPassword[]>([]);
+  const [isSyncingLocalPasswords, setIsSyncingLocalPasswords] = useState(false);
+  const [lastLocalSyncResult, setLastLocalSyncResult] = useState<LocalSyncResult | null>(null);
+  const syncAttemptedIdentityRef = useRef<string | null>(null);
 
-  const isAuthenticated = !!data?.session;
+  const authenticatedIdentity = data?.session?.id ?? data?.user?.id ?? null;
+  const isAuthenticated = authenticatedIdentity !== null;
 
   useEffect(() => {
     if (isPending) return;
 
     if (!isAuthenticated) {
-      try {
-        const stored = localStorage.getItem(LOCAL_STORAGE_KEY);
-        if (stored) {
-          const passwords: LocalStoredPassword[] = JSON.parse(stored);
-          setLocalPasswords(
-            passwords.map((p: LocalStoredPassword) => ({
-              ...p,
-              createdAt: new Date(p.createdAt),
-            }))
-          );
-        }
-      } catch (error) {
-        console.error('Error loading passwords from local storage:', error);
-      }
+      syncAttemptedIdentityRef.current = null;
+      lastCompletedLocalSyncIdentity = null;
+      setIsSyncingLocalPasswords(false);
+      setLastLocalSyncResult(null);
+      setLocalPasswords(readLocalPasswords());
     } else {
       setLocalPasswords([]);
     }
   }, [isPending, isAuthenticated]);
+
+  const syncLocalPasswordsToCloud = useCallback(async (): Promise<LocalSyncResult> => {
+    if (!authenticatedIdentity) {
+      lastCompletedLocalSyncIdentity = null;
+      const noSyncResult = { synced: 0, failed: 0 };
+      setLastLocalSyncResult(noSyncResult);
+      return noSyncResult;
+    }
+
+    if (localSyncInFlight?.identity === authenticatedIdentity) {
+      setIsSyncingLocalPasswords(true);
+      try {
+        const result = await localSyncInFlight.promise;
+        setLastLocalSyncResult(result);
+        return result;
+      } finally {
+        setIsSyncingLocalPasswords(false);
+      }
+    }
+
+    const localPasswordsToSync = readLocalPasswords();
+    if (localPasswordsToSync.length === 0) {
+      const noSyncResult = { synced: 0, failed: 0 };
+      setLastLocalSyncResult(noSyncResult);
+      return noSyncResult;
+    }
+
+    if (lastCompletedLocalSyncIdentity === authenticatedIdentity) {
+      const noRemainingPasswords = readLocalPasswords();
+      if (noRemainingPasswords.length === 0) {
+        const noSyncResult = { synced: 0, failed: 0 };
+        setLastLocalSyncResult(noSyncResult);
+        return noSyncResult;
+      }
+    }
+
+    setIsSyncingLocalPasswords(true);
+
+    const syncPromise = Promise.resolve().then(async (): Promise<LocalSyncResult> => {
+      try {
+        const response = await fetch('/api/v1/passwords');
+        if (!response.ok) {
+          return { synced: 0, failed: localPasswordsToSync.length };
+        }
+
+        const cloudPasswords: ApiStoredPassword[] = await response.json();
+        const cloudFingerprints = new Set(
+          cloudPasswords.map((password) => fingerprintPassword(password))
+        );
+        const unsyncedPasswords: StoredPassword[] = [];
+        let synced = 0;
+
+        for (const password of localPasswordsToSync) {
+          if (cloudFingerprints.has(fingerprintPassword(password))) {
+            synced += 1;
+            continue;
+          }
+
+          unsyncedPasswords.push(password);
+        }
+
+        const settledResults = await Promise.allSettled(
+          unsyncedPasswords.map(async (password) => {
+            const response = await fetch('/api/v1/passwords', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(toPasswordPayload(password)),
+            });
+
+            if (!response.ok) {
+              throw new Error('Error saving password');
+            }
+
+            return password;
+          })
+        );
+
+        const failedPasswords: StoredPassword[] = [];
+
+        settledResults.forEach((result, index) => {
+          if (result.status === 'fulfilled') {
+            synced += 1;
+            return;
+          }
+
+          failedPasswords.push(unsyncedPasswords[index]);
+        });
+
+        const failed = failedPasswords.length;
+        if (failed === 0) {
+          localStorage.removeItem(LOCAL_STORAGE_KEY);
+          setLocalPasswords([]);
+        } else {
+          writeLocalPasswords(failedPasswords);
+          setLocalPasswords(failedPasswords);
+        }
+
+        return { synced, failed };
+      } catch (error) {
+        console.error('Error syncing local passwords to database:', error);
+        return { synced: 0, failed: localPasswordsToSync.length };
+      }
+    });
+
+    localSyncInFlight = {
+      identity: authenticatedIdentity,
+      promise: syncPromise,
+    };
+
+    try {
+      const result = await syncPromise;
+      setLastLocalSyncResult(result);
+      return result;
+    } finally {
+      localSyncInFlight = null;
+      lastCompletedLocalSyncIdentity = authenticatedIdentity;
+      setIsSyncingLocalPasswords(false);
+    }
+  }, [authenticatedIdentity]);
+
+  useEffect(() => {
+    if (isPending) return;
+    if (!authenticatedIdentity) return;
+    if (syncAttemptedIdentityRef.current === authenticatedIdentity) return;
+
+    syncAttemptedIdentityRef.current = authenticatedIdentity;
+    void syncLocalPasswordsToCloud();
+  }, [authenticatedIdentity, isPending, syncLocalPasswordsToCloud]);
 
   const savePassword = useCallback(
     async (passwordData: Omit<StoredPassword, 'id' | 'createdAt'>) => {
@@ -90,13 +279,16 @@ export const usePasswordStorage = () => {
           throw error;
         }
       } else {
-        const updatedPasswords = [newPassword, ...localPasswords].slice(0, MAX_LOCAL_PASSWORDS);
+        const updatedPasswords = [newPassword, ...readLocalPasswords()].slice(
+          0,
+          MAX_LOCAL_PASSWORDS
+        );
         setLocalPasswords(updatedPasswords);
-        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(updatedPasswords));
+        writeLocalPasswords(updatedPasswords);
         return newPassword;
       }
     },
-    [isAuthenticated, localPasswords]
+    [isAuthenticated]
   );
 
   const getPasswords = useCallback(async (): Promise<StoredPassword[]> => {
@@ -105,18 +297,18 @@ export const usePasswordStorage = () => {
         const response = await fetch('/api/v1/passwords');
         if (!response.ok) throw new Error('Error fetching passwords');
         const passwords: ApiStoredPassword[] = await response.json();
-        return passwords.map((p: ApiStoredPassword) => ({
-          ...p,
-          createdAt: new Date(p.createdAt),
+        return passwords.map((password: ApiStoredPassword) => ({
+          ...password,
+          createdAt: new Date(password.createdAt),
         }));
       } catch (error) {
         console.error('Error fetching passwords from database:', error);
         return [];
       }
-    } else {
-      return localPasswords;
     }
-  }, [isAuthenticated, localPasswords]);
+
+    return readLocalPasswords();
+  }, [isAuthenticated]);
 
   const deletePassword = useCallback(
     async (id: string) => {
@@ -131,18 +323,21 @@ export const usePasswordStorage = () => {
           throw error;
         }
       } else {
-        const updatedPasswords = localPasswords.filter((p) => p.id !== id);
+        const updatedPasswords = readLocalPasswords().filter((p) => p.id !== id);
         setLocalPasswords(updatedPasswords);
-        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(updatedPasswords));
+        writeLocalPasswords(updatedPasswords);
       }
     },
-    [isAuthenticated, localPasswords]
+    [isAuthenticated]
   );
 
   return {
     savePassword,
     getPasswords,
     deletePassword,
+    syncLocalPasswordsToCloud,
+    isSyncingLocalPasswords,
+    lastLocalSyncResult,
     passwords: isAuthenticated ? [] : localPasswords,
     isAuthenticated,
     isLoading: isPending,


### PR DESCRIPTION
## Summary
- Sync guest `localStorage` passwords to the authenticated vault after login.
- Deduplicate against existing cloud passwords by password-generation fingerprint.
- Preserve failed sync entries locally for later retry and reload the vault after sync completes.

## Validation
- `pnpm check`
- `pnpm typecheck`
- `pnpm test`